### PR TITLE
Addressing MX notes per spec 1.35

### DIFF
--- a/src/shaders/MaterialX/color2.h
+++ b/src/shaders/MaterialX/color2.h
@@ -39,21 +39,24 @@ color2 make_color2()
 
 }
 
-color2 abs(color2 in){
+color2 abs(color2 in)
+{
     color2 out;
     out.r = abs(in.r);
     out.g = abs(in.g);
     return out;
 }
 
-color2 floor(color2 in){
+color2 floor(color2 in)
+{
     color2 out;
     out.r = floor(in.r);
     out.g = floor(in.g);
     return out;
 }
 
-color2 mix(color2 value1, color2 value2, float x ){
+color2 mix(color2 value1, color2 value2, float x )
+{
     color2 out;
     
     out.r = mix(value1.r, value2.r, x);
@@ -62,42 +65,48 @@ color2 mix(color2 value1, color2 value2, float x ){
     return out;
 }
 
-color2 add(color2 in, color2 amount){
+color2 add(color2 in, color2 amount)
+{
     color2 out = in;
     out.r = in.r + amount.r;
     out.g = in.g + amount.g;
     return out;
 }
 
-color2 add(color2 in, float amount){
+color2 add(color2 in, float amount)
+{
     color2 out = in;
     out.r = in.r + amount;
     out.g = in.g + amount;
     return out;
 }
 
-color2 subtract(color2 in, color2 amount){
+color2 subtract(color2 in, color2 amount)
+{
     color2 out = in;
     out.r = in.r - amount.r;
     out.g = in.g - amount.g;
     return out;
 }    
 
-color2 subtract(color2 in, float amount){
+color2 subtract(color2 in, float amount)
+{
     color2 out = in;
     out.r = in.r - amount;
     out.g = in.g - amount;
     return out;
 }    
 
-color2 smoothstep(color2 low, color2 high, color2 in){
+color2 smoothstep(color2 low, color2 high, color2 in)
+{
     color2 out = in;
     out.r = smoothstep(low.r, high.r, in.r);
     out.g = smoothstep(low.g, high.g, in.g);
     return out;
 }    
 
-color2 smoothstep(float low, float high, color2 in){
+color2 smoothstep(float low, float high, color2 in)
+{
     color2 out = in;
     out.r = smoothstep(low, high, in.r);
     out.g = smoothstep(low, high, in.g);
@@ -106,258 +115,285 @@ color2 smoothstep(float low, float high, color2 in){
 
 color2 remap(color2 in, color2 inLow, color2 inHigh, color2 outLow, color2 outHigh, int doClamp)
 {
-      //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
-
-      color2 out = in;
-      out.r = remap(in.r, inLow.r, inHigh.r, outLow.r, outHigh.r, doClamp);
-      out.g = remap(in.g, inLow.g, inHigh.g, outLow.g, outHigh.g, doClamp);
-      return out;
+    //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
+    color2 out = in;
+    out.r = remap(in.r, inLow.r, inHigh.r, outLow.r, outHigh.r, doClamp);
+    out.g = remap(in.g, inLow.g, inHigh.g, outLow.g, outHigh.g, doClamp);
+    return out;
 }
 
 color2 remap(color2 in, float inLow, float inHigh, float outLow, float outHigh, int doClamp)
 {
-      //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
-
-      color2 out = in;
-      out.r = remap(in.r, inLow, inHigh, outLow, outHigh, doClamp);
-      out.g = remap(in.g, inLow, inHigh, outLow, outHigh, doClamp);
-      return out;
+    //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
+    color2 out = in;
+    out.r = remap(in.r, inLow, inHigh, outLow, outHigh, doClamp);
+    out.g = remap(in.g, inLow, inHigh, outLow, outHigh, doClamp);
+    return out;
 }
 
 color2 fgamma(color2 in, color2 g){
     color2 out = in;
-
     out.r = fgamma(in.r, g.r);
     out.g = fgamma(in.g, g.g);
-      return out;
+    return out;
 }
 
-color2 fgamma(color2 in, float g){
+color2 fgamma(color2 in, float g)
+{
     color2 out = in;
 
     out.r = fgamma(in.r, g);
     out.g = fgamma(in.g, g);
-      return out;
+    return out;
 }
 
-color2 invert(color2 in, color2 amount){
+color2 invert(color2 in, color2 amount)
+{
     color2 out = in;
     out.r = amount.r - in.r;
     out.g = amount.g - in.g;
     return out;
 }
 
-color2 invert(color2 in, float amount){
+color2 invert(color2 in, float amount)
+{
     color2 out = in;
     out.r = amount - in.r;
     out.g = amount - in.g;
     return out;
 }
 
-color2 invert(color2 in){
+color2 invert(color2 in)
+{
     color2 out = invert(in, 1.0);
     return out;
 }
 
-color2 clamp(color2 in, color2 low, color2 high){
+color2 clamp(color2 in, color2 low, color2 high)
+{
     color2 out = in;
     out.r = clamp(in.r, low.r, high.r);
     out.g = clamp(in.g, low.g, high.g);
     return out;
 }
 
-color2 clamp(color2 in, float low, float high){
+color2 clamp(color2 in, float low, float high)
+{
     color2 out = in;
     out.r = clamp(in.r, low, high);
     out.g = clamp(in.g, low, high);
     return out;
 }
 
-color2 contrast(color2 in, color2 amount, color2 pivot){
+color2 contrast(color2 in, color2 amount, color2 pivot)
+{
     color2 out = in;
     out.r = contrast(in.r, amount.r, pivot.r);
     out.g = contrast(in.g, amount.g, pivot.g);
     return out;
-}    
+}
 
-color2 contrast(color2 in, float amount, float pivot){
+color2 contrast(color2 in, float amount, float pivot)
+{
     color2 out = in;
     out.r = contrast(in.r, amount, pivot);
     out.g = contrast(in.g, amount, pivot);
     return out;
-}    
+}
 
-color2 divide(color2 in1, color2 amount){
+color2 divide(color2 in1, color2 amount)
+{
     color2 out = in1;
     out.r = in1.r / amount.r;
     out.g = in1.g / amount.g;
     return out;
 }
 
-color2 divide(color2 in1, float amount){
+color2 divide(color2 in1, float amount)
+{
     color2 out = in1;
     out.r = in1.r / amount;
     out.g = in1.g / amount;
     return out;
 }
 
-color2 exponent(color2 in, color2 amount){
+color2 exponent(color2 in, color2 amount)
+{
     color2 out = in;
     out.r = exponent(in.r, amount.r);
     out.g = exponent(in.g, amount.g);
     return out;
 }
 
-color2 exponent(color2 in, float amount){
+color2 exponent(color2 in, float amount)
+{
     color2 out = in;
     out.r = exponent(in.r, amount);
     out.g = exponent(in.g, amount);
     return out;
 }
 
-color2 max(color2 in, color2 amount){
+color2 max(color2 in, color2 amount)
+{
     color2 out = in;
     out.r = max(in.r, amount.r);
     out.g = max(in.g, amount.g);
     return out;
 }
 
-color2 max(color2 in, float amount){
+color2 max(color2 in, float amount)
+{
     color2 out = in;
     out.r = max(in.r, amount);
     out.g = max(in.g, amount);
     return out;
 }
 
-color2 multiply(color2 in1, color2 amount){
+color2 multiply(color2 in1, color2 amount)
+{
     color2 out = in1;
     out.r = in1.r * amount.r;
     out.g = in1.g * amount.g;
     return out;
 }
 
-color2 multiply(color2 in1, float amount){
+color2 multiply(color2 in1, float amount)
+{
     color2 out = in1;
     out.r = in1.r * amount;
     out.g = in1.g * amount;
     return out;
 }
 
-color2 min(color2 in, color2 amount){
+color2 min(color2 in, color2 amount)
+{
     color2 out = in;
     out.r = min(in.r, amount.r);
     out.g = min(in.g, amount.g);
     return out;
 }
 
-color2 min(color2 in, float amount){
+color2 min(color2 in, float amount)
+{
     color2 out = in;
     out.r = min(in.r, amount);
     out.g = min(in.g, amount);
     return out;
 }
 
-color2 fmod(color2 in, color2 amount){
+color2 fmod(color2 in, color2 amount)
+{
     color2 out = in;
     out.r = fmod(in.r, amount.r);
     out.g = fmod(in.g, amount.g);
     return out;
 }
 
-color2 fmod(color2 in, float amount){
+color2 fmod(color2 in, float amount)
+{
     color2 out = in;
     out.r = fmod(in.r, amount);
     out.g = fmod(in.g, amount);
     return out;
 }
 
-color2 unpremult(color2 in){
+color2 unpremult(color2 in)
+{
     color2 out = in;
     out.r = in.r / in.g;
     return out;
 }
 
-color2 premult(color2 in){
+color2 premult(color2 in)
+{
     color2 out = in;
     out.r = in.r * in.g;
     return out;
 }
 
-color2 cout(color2 fg, color2 bg){
+color2 cout(color2 fg, color2 bg)
+{
     color2 out;
     out.r = fg.r * (1 - bg.g);
     out.g = fg.g * (1 - bg.g);
     return out;
 }
 
-color2 over(color2 fg, color2 bg){
+color2 over(color2 fg, color2 bg)
+{
     color2 over;
     over.r = fg.r + bg.r * (1 - fg.g);
     over.g = fg.g + bg.g * (1 - fg.g);
     return over;
 }
 
-color2 cmatte(color2 fg, color2 bg){
+color2 cmatte(color2 fg, color2 bg)
+{
     color2 out;
     out.r = (fg.r * fg.g) + bg.r * (1 - fg.g);
     out.g = fg.g + bg.g * (1 - fg.g);
     return out;
 }
 
-color2 cmask(color2 fg, color2 bg){
+color2 cmask(color2 fg, color2 bg)
+{
     color2 out;
     out.r = bg.r * fg.g;
     out.g = bg.g * fg.g;
     return out;
 }
 
-color2 cin(color2 fg, color2 bg){
+color2 cin(color2 fg, color2 bg)
+{
     color2 out;
     out.r = fg.r * bg.g;
     out.g = fg.g * bg.g;
     return out;
 }
 
-color2 disjointover(color2 fg, color2 bg){
+color2 disjointover(color2 fg, color2 bg)
+{
     float summedAlpha = fg.g + bg.g;
-
     color2 out;
     if (summedAlpha <= 1){
         out.r = fg.r + bg.r;
-    }else{
+    } else {
         out.r = fg.r + ((bg.r * (1-fg.g)) / bg.g);
     }
-
     out.g = min(summedAlpha, 1);
     return out;
 }
 
-color2 dodge(color2 fg, color2 bg){
-    color2 out = { dodge(fg.r, bg.r),  
-                 dodge(fg.g, bg.g)
-               };
+color2 dodge(color2 fg, color2 bg)
+{
+    color2 out = { dodge(fg.r, bg.r),
+                   dodge(fg.g, bg.g)
+                 };
 
     return out;
 }
 
-color2 screen(color2 fg, color2 bg){
-    color2 out = { screen(fg.r, bg.r),  
+color2 screen(color2 fg, color2 bg)
+{
+    color2 out = { screen(fg.r, bg.r),
                  screen(fg.g, bg.g)
                };
 
     return out;
 }
 
-color2 overlay(color2 fg, color2 bg){
-    color2 out = { overlay(fg.r, bg.r),  
-                 overlay(fg.g, bg.g)
-                };
+color2 overlay(color2 fg, color2 bg)
+{
+    color2 out = { overlay(fg.r, bg.r),
+                   overlay(fg.g, bg.g)
+                  };
 
     return out;
 }
 
-color2 difference(color2 fg, color2 bg){
-    color2 out = { difference(fg.r, bg.r),  
+color2 difference(color2 fg, color2 bg)
+{
+    color2 out = { difference(fg.r, bg.r),
                  difference(fg.g, bg.g)
                };
     return out;

--- a/src/shaders/MaterialX/color4.h
+++ b/src/shaders/MaterialX/color4.h
@@ -45,70 +45,78 @@ color4 make_color4(color rgb)
     return out;
 }
 
-color4 abs(color4 in){
+color4 abs(color4 in)
+{
     color4 out;
     out.rgb = abs(in.rgb);
     out.a = abs(in.a);
     return out;
 }
 
-color4 floor(color4 in){
+color4 floor(color4 in)
+{
     color4 out;
     out.rgb = floor(in.rgb);
     out.a = floor(in.a);
     return out;
 }
 
-color4 mix(color4 value1, color4 value2, float x ){
+color4 mix(color4 value1, color4 value2, float x )
+{
     color4 out;
-    
     out.rgb = mix(value1.rgb, value2.rgb, x);
     out.a = mix(value1.a, value2.a, x);
-
     return out;
 }
 
-color4 add(color4 in, color4 amount){
+color4 add(color4 in, color4 amount)
+{
     color4 out = in;
     out.rgb = in.rgb + amount.rgb;
     out.a = in.a + amount.a;
     return out;
 }
 
-color4 add(color4 in, float amount){
+color4 add(color4 in, float amount)
+{
     color4 out = in;
     out.rgb = in.rgb + amount;
     out.a = in.a + amount;
     return out;
 }
 
-color4 luminance(color4 in){
-    color4 out = {color(luminance(in.rgb)), in.a};
+color4 cluminance(color4 in, color lumacoeffs)
+{
+    color4 out = {color(cluminance(in.rgb, lumacoeffs)), in.a};
     return out;
 }
 
-color4 subtract(color4 in, color4 amount){
+color4 subtract(color4 in, color4 amount)
+{
     color4 out = in;
     out.rgb = in.rgb - amount.rgb;
     out.a = in.a - amount.a;
     return out;
 }
 
-color4 subtract(color4 in, float amount){
+color4 subtract(color4 in, float amount)
+{
     color4 out = in;
     out.rgb = in.rgb - amount;
     out.a = in.a - amount;
     return out;
 }
 
-color4 smoothstep(color4 low, color4 high, color4 in){
+color4 smoothstep(color4 low, color4 high, color4 in)
+{
     color4 out = in;
     out.rgb = smoothstep(low.rgb, high.rgb, in.rgb);
     out.a = smoothstep(low.a, high.a, in.a);
     return out;
 }
 
-color4 smoothstep(float low, float high, color4 in){
+color4 smoothstep(float low, float high, color4 in)
+{
     color4 out = in;
     out.rgb = smoothstep(low, high, in.rgb);
     out.a = smoothstep(low, high, in.a);
@@ -128,91 +136,100 @@ color4 remap(color4 in, color4 inLow, color4 inHigh, color4 outLow, color4 outHi
 color4 remap(color4 in, float inLow, float inHigh, float outLow, float outHigh, int doClamp)
 {
       //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
-
       color4 out = in;
       out.rgb = remap(in.rgb, inLow, inHigh, outLow, outHigh, doClamp);
       out.a = remap(in.a, inLow, inHigh, outLow, outHigh, doClamp);
       return out;
 }
 
-color4 fgamma(color4 in, color4 g){
+color4 fgamma(color4 in, color4 g)
+{
     color4 out = in;
-
     out.rgb = fgamma(in.rgb, g.rgb);
     out.a = fgamma(in.a, g.a);
-      return out;
+    return out;
 }
 
-color4 fgamma(color4 in, float g){
+color4 fgamma(color4 in, float g)
+{
     color4 out = in;
-
     out.rgb = fgamma(in.rgb, g);
     out.a = fgamma(in.a, g);
-      return out;
+    return out;
 }
 
-color4 invert(color4 in, color4 amount){
+color4 invert(color4 in, color4 amount)
+{
     color4 out = in;
     out.rgb = amount.rgb - in.rgb;
     out.a = amount.a - in.a;
     return out;
 }
 
-color4 invert(color4 in, float amount){
+color4 invert(color4 in, float amount)
+{
     color4 out = in;
     out.rgb = color(amount) - in.rgb;
     out.a = amount - in.a;
     return out;
 }
 
-color4 invert(color4 in){
+color4 invert(color4 in)
+{
     color4 out = invert(in, 1.0);
     return out;
 }
 
-color4 clamp(color4 in, color4 low, color4 high){
+color4 clamp(color4 in, color4 low, color4 high)
+{
     color4 out = in;
     out.rgb = clamp(in.rgb, low.rgb, high.rgb);
     out.a = clamp(in.a, low.a, high.a);
     return out;
 }
 
-color4 clamp(color4 in, float low, float high){
+color4 clamp(color4 in, float low, float high)
+{
     color4 out = in;
     out.rgb = clamp(in.rgb, low, high);
     out.a = clamp(in.a, low, high);
     return out;
 }
 
-color4 contrast(color4 in, color4 amount, color4 pivot){
+color4 contrast(color4 in, color4 amount, color4 pivot)
+{
     color4 out = in;
     out.rgb = contrast(in.rgb, amount.rgb, pivot.rgb);
     out.a = contrast(in.a, amount.a, pivot.a);
     return out;
 }
 
-color4 contrast(color4 in, float amount, float pivot){
+color4 contrast(color4 in, float amount, float pivot)
+{
     color4 out = in;
     out.rgb = contrast(in.rgb, amount, pivot);
     out.a = contrast(in.a, amount, pivot);
     return out;
 }
 
-color4 divide(color4 in1, color4 amount){
+color4 divide(color4 in1, color4 amount)
+{
     color4 out = in1;
     out.rgb = in1.rgb / amount.rgb;
     out.a = in1.a / amount.a;
     return out;
 }
 
-color4 divide(color4 in1, float amount){
+color4 divide(color4 in1, float amount)
+{
     color4 out = in1;
     out.rgb = in1.rgb / amount;
     out.a = in1.a / amount;
     return out;
 }
 
-color4 exponent(color4 in, color4 amount){
+color4 exponent(color4 in, color4 amount)
+{
     color4 out = in;
     out.rgb = exponent(in.rgb, amount.rgb);
     out.a = exponent(in.a, amount.a);
@@ -220,89 +237,102 @@ color4 exponent(color4 in, color4 amount){
 }
 
 
-color4 exponent(color4 in, float amount){
+color4 exponent(color4 in, float amount)
+{
     color4 out = in;
     out.rgb = exponent(in.rgb, amount);
     out.a = exponent(in.a, amount);
     return out;
 }
 
-color4 max(color4 in, color4 amount){
+color4 max(color4 in, color4 amount)
+{
     color4 out = in;
     out.rgb = max(in.rgb, amount.rgb);
     out.a = max(in.a, amount.a);
     return out;
 }
 
-color4 max(color4 in, float amount){
+color4 max(color4 in, float amount)
+{
     color4 out = in;
     out.rgb = max(in.rgb, amount);
     out.a = max(in.a, amount);
     return out;
 }
 
-color4 multiply(color4 in1, color4 amount){
+color4 multiply(color4 in1, color4 amount)
+{
     color4 out = in1;
     out.rgb = in1.rgb * amount.rgb;
     out.a = in1.a * amount.a;
     return out;
 }
 
-color4 multiply(color4 in1, float amount){
+color4 multiply(color4 in1, float amount)
+{
     color4 out = in1;
     out.rgb = in1.rgb * amount;
     out.a = in1.a * amount;
     return out;
 }
 
-color4 min(color4 in, color4 amount){
+color4 min(color4 in, color4 amount)
+{
     color4 out = in;
     out.rgb = min(in.rgb, amount.rgb);
     out.a = min(in.a, amount.a);
     return out;
 }
 
-color4 min(color4 in, float amount){
+color4 min(color4 in, float amount)
+{
     color4 out = in;
     out.rgb = min(in.rgb, amount);
     out.a = min(in.a, amount);
     return out;
 }
 
-color4 fmod(color4 in, color4 amount){
+color4 fmod(color4 in, color4 amount)
+{
     color4 out = in;
     out.rgb = fmod(in.rgb, amount.rgb);
     out.a = fmod(in.a, amount.a);
     return out;
 }
 
-color4 fmod(color4 in, float amount){
+color4 fmod(color4 in, float amount)
+{
     color4 out = in;
     out.rgb = fmod(in.rgb, amount);
     out.a = fmod(in.a, amount);
     return out;
 }
 
-color4 unpremult(color4 in){
+color4 unpremult(color4 in)
+{
    color4 out = in;
    out.rgb = unpremult(in.rgb, in.a);
    return out;
 }
 
-color4 premult(color4 in){
+color4 premult(color4 in)
+{
    color4 out = in;
    out.rgb = premult(in.rgb, in.a);
    return out;
 }
 
-color4 saturate(color4 in, float amount){
+color4 saturate(color4 in, float amount)
+{
     color hsv3 = transformc("rgb","hsv", in.rgb);
     hsv3[1] *= amount;
     color4 out = {transformc("hsv","rgb", hsv3), in.a};
     return out;
 }
 
-color4 hueshift(color4 in, float amount){
+color4 hueshift(color4 in, float amount)
+{
     color hsv3 = transformc("rgb","hsv", in.rgb);
     hsv3[0] += amount;
     hsv3[0] = fmod(hsv3[0], 1.0);
@@ -310,54 +340,55 @@ color4 hueshift(color4 in, float amount){
     return out;
 }
 
-color4 over(color4 fg, color4 bg){
+color4 over(color4 fg, color4 bg)
+{
     color4 over;
     float x = 1 - fg.a;
     over.rgb = fg.rgb + bg.rgb * (1 - fg.a);
-
     over.a = fg.a + bg.a * (1 - fg.a);
     return over;
 }
 
-color4 cout(color4 fg, color4 bg){
+color4 cout(color4 fg, color4 bg)
+{
     color4 out;
     out.rgb = fg.rgb * (1 - bg.a);
-
     out.a = fg.a * (1 - bg.a);
     return out;
 }
 
-color4 cmatte(color4 fg, color4 bg){
+color4 cmatte(color4 fg, color4 bg)
+{
     color4 out;
     out.rgb = (fg.rgb * fg.a) + bg.rgb * (1 - fg.a);
-
     out.a = fg.a + bg.a * (1 - fg.a);
     return out;
 }
 
-color4 cmask(color4 fg, color4 bg){
+color4 cmask(color4 fg, color4 bg)
+{
     color4 out;
     out.rgb = bg.rgb * fg.a;
-
     out.a = bg.a * fg.a;
     return out;
 }
 
-color4 cin(color4 fg, color4 bg){
+color4 cin(color4 fg, color4 bg)
+{
     color4 out;
     out.rgb = fg.rgb * bg.a;
-
     out.a = fg.a * bg.a;
     return out;
 }
 
-color4 disjointover(color4 fg, color4 bg){
+color4 disjointover(color4 fg, color4 bg)
+{
     float summedAlpha = fg.a + bg.a;
 
     color4 out;
     if (summedAlpha <= 1){
         out.rgb = fg.rgb + bg.rgb;
-    }else{
+    } else {
         float x = (1-fg.a) / bg.a;
         out.rgb = fg.rgb + bg.rgb * x;
         
@@ -367,35 +398,38 @@ color4 disjointover(color4 fg, color4 bg){
     return out;
 }
 
-color4 dodge(color4 fg, color4 bg){
-    color4 out = { dodge(fg.rgb, bg.rgb),  
-
-                 dodge(fg.a, bg.a)
-               };
-
-    return out;
-}
-
-color4 screen(color4 fg, color4 bg){
-    color4 out = { screen(fg.rgb, bg.rgb),   
-                 screen(fg.a, bg.a)
-               };
+color4 dodge(color4 fg, color4 bg)
+{
+    color4 out = { dodge(fg.rgb, bg.rgb),
+                   dodge(fg.a, bg.a)
+                 };
 
     return out;
 }
 
-color4 overlay(color4 fg, color4 bg){
-    color4 out = { overlay(fg.rgb, bg.rgb),  
-                 overlay(fg.a, bg.a)
-               };
+color4 screen(color4 fg, color4 bg)
+{
+    color4 out = { screen(fg.rgb, bg.rgb),
+                   screen(fg.a, bg.a)
+                 };
 
     return out;
 }
 
-color4 difference(color4 fg, color4 bg){
-    color4 out = { difference(fg.rgb, bg.rgb),  
-                 difference(fg.a, bg.a)
-               };
+color4 overlay(color4 fg, color4 bg)
+{
+    color4 out = { overlay(fg.rgb, bg.rgb),
+                   overlay(fg.a, bg.a)
+                 };
+
+    return out;
+}
+
+color4 difference(color4 fg, color4 bg)
+{
+    color4 out = { difference(fg.rgb, bg.rgb),
+                   difference(fg.a, bg.a)
+                 };
 
     return out;
 }

--- a/src/shaders/MaterialX/funcs.h
+++ b/src/shaders/MaterialX/funcs.h
@@ -25,7 +25,8 @@ TYPE fmod(TYPE in, float amount){return fmod(in, amount); }
 
 #endif
 
-color smoothstep(color low, color high, color in){
+color smoothstep(color low, color high, color in)
+{
     color out = in;
     out[0] = smoothstep(low[0], high[0], in[0]);
     out[1] = smoothstep(low[1], high[1], in[1]);
@@ -33,7 +34,8 @@ color smoothstep(color low, color high, color in){
     return out;
 }
 
-color smoothstep(float low, float high, color in){
+color smoothstep(float low, float high, color in)
+{
     color out = in;
     out[0] = smoothstep(low, high, in[0]);
     out[1] = smoothstep(low, high, in[1]);
@@ -81,34 +83,52 @@ color fgamma(color in, float g){ return sign(in) * pow(abs(in), g);}
 color premult(color in, float alpha) { return in * alpha; }
 color unpremult(color in, float alpha) { return in * (1/alpha); }
 
-float contrast(float in, float amount, float pivot){
+float contrast(float in, float amount, float pivot)
+{
     float out = in - pivot;
     out *= amount;
     out += pivot;
     return out;
 }
 
-color contrast(color in, color amount, color pivot){
+color contrast(color in, color amount, color pivot)
+{
     color out = in - pivot;
     out *= amount;
     out += pivot;
     return out;
 }
 
-color contrast(color in, float amount, float pivot){
+color contrast(color in, float amount, float pivot)
+{
     color out = in - pivot;
     out *= amount;
     out += pivot;
     return out;
 }
-float exponent(float in, float amount){ return (in > 0) ? pow(in, amount) : in;}
-color exponent(color in, color amount){ return (luminance(in) > 0) ? pow(in, amount) : in; }
-color exponent(color in, float amount){ return (luminance(in) > 0) ? pow(in, amount) : in; }
+float exponent(float in, float amount)
+{ 
+    return (in > 0) ? pow(in, amount) : in;
+}
+color exponent(color in, color amount)
+{ 
+    return (luminance(in) > 0) ? pow(in, amount) : in; 
+}
+color exponent(color in, float amount)
+{ 
+    return (luminance(in) > 0) ? pow(in, amount) : in; 
+}
 
-vector vscale(vector in, vector amount, vector center){ return ((in - center)/amount); }
+vector vscale(vector in, vector amount, vector center){ return ((in - center)/amount + center); }
 float mag(vector in){    return length(in); }
 
-float fBm( point position, int octaves, float lacunarity, float diminish, string noisetype){
+float cluminance( color in, color lumacoeffs)
+{
+    return dot(in, lumacoeffs);
+}
+
+float fBm( point position, int octaves, float lacunarity, float diminish, string noisetype)
+{
 
     float out = 0;
     float amp = 1.0;
@@ -123,7 +143,8 @@ float fBm( point position, int octaves, float lacunarity, float diminish, string
     return out;
 }
 
-color fBm( point position, int octaves, float lacunarity, float diminish, string noisetype){
+color fBm( point position, int octaves, float lacunarity, float diminish, string noisetype)
+{
 
     color out = 0;
     float amp = 1.0;
@@ -138,7 +159,8 @@ color fBm( point position, int octaves, float lacunarity, float diminish, string
     return out;
 }
 
-color hueshift(color in, float amount){
+color hueshift(color in, float amount)
+{
     color hsv3 = transformc("rgb","hsv", in);
     hsv3[0] += amount;
     hsv3[0] = fmod(hsv3[0], 1.0);
@@ -146,7 +168,8 @@ color hueshift(color in, float amount){
     return out;
 }
 
-color saturate(color in, float amount){
+color saturate(color in, float amount)
+{
     color hsv3 = transformc("rgb","hsv", in);
     hsv3[1] *= amount;
     color out =  transformc("hsv","rgb", hsv3);
@@ -160,25 +183,29 @@ color screen(color fg, color bg){ return 1 - (1 - fg) * (1 - bg);}
 float difference(float fg, float bg){ return abs(fg - bg);}
 color difference(color fg, color bg){ return abs(fg - bg);}
 
-float overlay(float fg, float bg){
+float overlay(float fg, float bg)
+{
     if (fg < 0.5){
       return 2 * fg *bg;
     }
     return 1 - (1 - fg) * (1 - bg);
 }
 
-color overlay(color fg, color bg){
+color overlay(color fg, color bg)
+{
     if (luminance(fg) < 0.5){
       return 2 * fg * bg;
     }
     return color(1) - (color(1) - fg) * (color(1) - bg);
 }
 
-closure color add(closure color in1, closure color in2){
+closure color add(closure color in1, closure color in2)
+{
     return in1 + in2;
 }
 
-closure color mix(closure color in1, closure color in2, float mask){
+closure color mix(closure color in1, closure color in2, float mask)
+{
     return (in1 * mask) +  (in2 * (1.0-mask));
 }
 

--- a/src/shaders/MaterialX/mx_hueshift.mx
+++ b/src/shaders/MaterialX/mx_hueshift.mx
@@ -19,7 +19,7 @@ SHADER_NAME(mx_hueshift)
     [[ string help = "Shift the hue of a color; the alpha channel will be unchanged if present." ]]
   (
     TYPE in = TYPE_ZERO,
-    float amount = 0.0,
+    float amount = 0.5,
     output TYPE out = TYPE_ZERO
   )
 {

--- a/src/shaders/MaterialX/mx_luminance.mx
+++ b/src/shaders/MaterialX/mx_luminance.mx
@@ -13,8 +13,9 @@ SHADER_NAME(mx_luminance)
     [[ string help = "Output a grayscale image containing the luminance of the incoming RGB color in all color channels;" ]]
   (
     TYPE in = TYPE_ZERO,
+    color lumacoeffs = color(0.2126, 0.7152, 0.0722),
     output TYPE out = TYPE_ZERO
   )
 {
-    out = luminance(in);
+    out = cluminance(in, lumacoeffs);
 }

--- a/src/shaders/MaterialX/vector2.h
+++ b/src/shaders/MaterialX/vector2.h
@@ -21,72 +21,78 @@ vector2 make_vector2(float x, float y)
     return out;
 }
 
-vector2 abs(vector2 in){
+vector2 abs(vector2 in)
+{
     vector2 out;
     out.x = abs(in.x);
     out.y = abs(in.y);
     return out;
 }
 
-vector2 floor(vector2 in){
+vector2 floor(vector2 in)
+{
     vector2 out;
     out.x = floor(in.x);
     out.y = floor(in.y);
     return out;
 }
 
-vector2 mix(vector2 value1, vector2 value2, float x ){
+vector2 mix(vector2 value1, vector2 value2, float x )
+{
     vector2 out;
     
     out.x = mix(value1.x, value2.x, x);
     out.y = mix(value1.y, value2.y, x);
-
     return out;
 }
 
-float dot(vector2 a, vector2 b){
-    return dot(vector(a.x, a.y, 0), vector(b.x, b.y, 0));
+float dot(vector2 a, vector2 b)
+{
+    return (a.x*b.x + a.y*b.y);
 }
 
-vector2 add(vector2 in, vector2 amount){
+vector2 add(vector2 in, vector2 amount)
+{
     vector2 out = in;
     out.x = in.x + amount.x;
     out.y = in.y + amount.y;
     return out;
 }
 
-vector2 add(vector2 in, float amount){
+vector2 add(vector2 in, float amount)
+{
     vector2 out = in;
     out.x = in.x + amount;
     out.y = in.y + amount;
     return out;
 }
 
-vector2 subtract(vector2 in, vector2 amount){
+vector2 subtract(vector2 in, vector2 amount)
+{
     vector2 out = in;
     out.x = in.x - amount.x;
     out.y = in.y - amount.y;
-
     return out;
 }
 
-vector2 subtract(vector2 in, float amount){
+vector2 subtract(vector2 in, float amount)
+{
     vector2 out = in;
     out.x = in.x - amount;
     out.y = in.y - amount;
-
     return out;
 }
 
-vector2 smoothstep(vector2 low, vector2 high, vector2 in){
+vector2 smoothstep(vector2 low, vector2 high, vector2 in)
+{
     vector2 out = in;
     out.x = smoothstep(low.x, high.x, in.x);
     out.y = smoothstep(low.y, high.y, in.y);
-
     return out;
 }
 
-vector2 smoothstep(float low, float high, vector2 in){
+vector2 smoothstep(float low, float high, vector2 in)
+{
     vector2 out = in;
     out.x = smoothstep(low, high, in.x);
     out.y = smoothstep(low, high, in.y);
@@ -98,62 +104,68 @@ vector2 remap(vector2 in, vector2 inLow, vector2 inHigh, vector2 outLow, vector2
 {
       //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
 
-      vector2 out = in;
-      out.x = remap(in.x, inLow.x, inHigh.x, outLow.x, outHigh.x, doClamp);
-      out.y = remap(in.y, inLow.y, inHigh.y, outLow.y, outHigh.y, doClamp);
+    vector2 out = in;
+    out.x = remap(in.x, inLow.x, inHigh.x, outLow.x, outHigh.x, doClamp);
+    out.y = remap(in.y, inLow.y, inHigh.y, outLow.y, outHigh.y, doClamp);
 
-      return out;
+    return out;
 }
 
 vector2 remap(vector2 in, float inLow, float inHigh, float outLow, float outHigh, int doClamp)
 {
       //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
 
-      vector2 out = in;
-      out.x = remap(in.x, inLow, inHigh, outLow, outHigh, doClamp);
-      out.y = remap(in.y, inLow, inHigh, outLow, outHigh, doClamp);
+    vector2 out = in;
+    out.x = remap(in.x, inLow, inHigh, outLow, outHigh, doClamp);
+    out.y = remap(in.y, inLow, inHigh, outLow, outHigh, doClamp);
 
-      return out;
+    return out;
 }
 
-vector2 fgamma(vector2 in, vector2 g){
+vector2 fgamma(vector2 in, vector2 g)
+{
     vector2 out = in;
 
     out.x = fgamma(in.x, g.x);
     out.y = fgamma(in.y, g.y);
 
-      return out;
+    return out;
 }
 
-vector2 fgamma(vector2 in, float g){
+vector2 fgamma(vector2 in, float g)
+{
     vector2 out = in;
 
     out.x = fgamma(in.x, g);
     out.y = fgamma(in.y, g);
 
-      return out;
+    return out;
 }
 
-vector2 invert(vector2 in, vector2 amount){
+vector2 invert(vector2 in, vector2 amount)
+{
     vector2 out = in;
     out.x = amount.x - in.x;
     out.y = amount.y - in.y;
     return out;
 }
 
-vector2 invert(vector2 in, float amount){
+vector2 invert(vector2 in, float amount)
+{
     vector2 out = in;
     out.x = amount - in.x;
     out.y = amount - in.y;
     return out;
 }
 
-vector2 invert(vector2 in){
+vector2 invert(vector2 in)
+{
     vector2 out = invert(in, 1.0);
     return out;
 }
 
-vector2 clamp(vector2 in, vector2 low, vector2 high){
+vector2 clamp(vector2 in, vector2 low, vector2 high)
+{
     vector2 out = in;
     out.x = clamp(in.x, low.x, high.x);
     out.y = clamp(in.y, low.y, high.y);
@@ -161,7 +173,8 @@ vector2 clamp(vector2 in, vector2 low, vector2 high){
     return out;
 }
 
-vector2 clamp(vector2 in, float low, float high){
+vector2 clamp(vector2 in, float low, float high)
+{
     vector2 out = in;
     out.x = clamp(in.x, low, high);
     out.y = clamp(in.y, low, high);
@@ -169,7 +182,8 @@ vector2 clamp(vector2 in, float low, float high){
     return out;
 }
 
-vector2 contrast(vector2 in, vector2 amount, vector2 pivot){
+vector2 contrast(vector2 in, vector2 amount, vector2 pivot)
+{
     vector2 out = in;
     out.x = contrast(in.x, amount.x, pivot.x);
     out.y = contrast(in.y, amount.y, pivot.y);
@@ -177,7 +191,8 @@ vector2 contrast(vector2 in, vector2 amount, vector2 pivot){
     return out;
 }
 
-vector2 contrast(vector2 in, float amount, float pivot){
+vector2 contrast(vector2 in, float amount, float pivot)
+{
     vector2 out = in;
     out.x = contrast(in.x, amount, pivot);
     out.y = contrast(in.y, amount, pivot);
@@ -185,7 +200,8 @@ vector2 contrast(vector2 in, float amount, float pivot){
     return out;
 }
 
-vector2 divide(vector2 in1, vector2 amount){
+vector2 divide(vector2 in1, vector2 amount)
+{
     vector2 out = in1;
     out.x = in1.x / amount.x;
     out.y = in1.y / amount.y;
@@ -201,21 +217,24 @@ vector2 divide(vector2 in1, float amount){
     return out;
 }
 
-vector2 exponent(vector2 in, vector2 amount){
+vector2 exponent(vector2 in, vector2 amount)
+{
     vector2 out = in;
     out.x = exponent(in.x, amount.x);
     out.y = exponent(in.y, amount.y);
     return out;
 }
 
-vector2 exponent(vector2 in, float amount){
+vector2 exponent(vector2 in, float amount)
+{
     vector2 out = in;
     out.x = exponent(in.x, amount);
     out.y = exponent(in.y, amount);
     return out;
 }
 
-vector2 max(vector2 in, vector2 amount){
+vector2 max(vector2 in, vector2 amount)
+{
     vector2 out = in;
     out.x = max(in.x, amount.x);
     out.y = max(in.y, amount.y);
@@ -223,7 +242,8 @@ vector2 max(vector2 in, vector2 amount){
     return out;
 }
 
-vector2 max(vector2 in, float amount){
+vector2 max(vector2 in, float amount)
+{
     vector2 out = in;
     out.x = max(in.x, amount);
     out.y = max(in.y, amount);
@@ -231,7 +251,8 @@ vector2 max(vector2 in, float amount){
     return out;
 }
 
-vector2 normalize(vector2 in){
+vector2 normalize(vector2 in)
+{
     vector v = normalize(vector(in.x, in.y, 0));
     vector2 out;
     out.x = v[0];
@@ -239,14 +260,16 @@ vector2 normalize(vector2 in){
     return out;
 }
 
-vector2 vscale(vector2 in, vector2 amount, vector2 center){
+vector2 vscale(vector2 in, vector2 amount, vector2 center)
+{
     vector2 out;
-    out.x = (in.x - center.x)/amount.x;
-    out.y = (in.y - center.y)/amount.y;
+    out.x = (in.x - center.x)/amount.x + center.x;
+    out.y = (in.y - center.y)/amount.y + center.y;
     return out;
 }
 
-vector2 multiply(vector2 in1, vector2 amount){
+vector2 multiply(vector2 in1, vector2 amount)
+{
     vector2 out = in1;
     out.x = in1.x * amount.x;
     out.y = in1.y * amount.y;
@@ -254,7 +277,8 @@ vector2 multiply(vector2 in1, vector2 amount){
     return out;
 }
 
-vector2 multiply(vector2 in1, float amount){
+vector2 multiply(vector2 in1, float amount)
+{
     vector2 out = in1;
     out.x = in1.x * amount;
     out.y = in1.y * amount;
@@ -262,7 +286,8 @@ vector2 multiply(vector2 in1, float amount){
     return out;
 }
 
-vector2 min(vector2 in, vector2 amount){
+vector2 min(vector2 in, vector2 amount)
+{
     vector2 out = in;
     out.x = min(in.x, amount.x);
     out.y = min(in.y, amount.y);
@@ -270,7 +295,8 @@ vector2 min(vector2 in, vector2 amount){
     return out;
 }
 
-vector2 min(vector2 in, float amount){
+vector2 min(vector2 in, float amount)
+{
     vector2 out = in;
     out.x = min(in.x, amount);
     out.y = min(in.y, amount);
@@ -278,7 +304,8 @@ vector2 min(vector2 in, float amount){
     return out;
 }
 
-vector2 fmod(vector2 in, vector2 amount){
+vector2 fmod(vector2 in, vector2 amount)
+{
     vector2 out = in;
     out.x = fmod(in.x, amount.x);
     out.y = fmod(in.y, amount.y);
@@ -286,7 +313,8 @@ vector2 fmod(vector2 in, vector2 amount){
     return out;
 }
 
-vector2 fmod(vector2 in, float amount){
+vector2 fmod(vector2 in, float amount)
+{
     vector2 out = in;
     out.x = fmod(in.x, amount);
     out.y = fmod(in.y, amount);
@@ -298,18 +326,18 @@ float mag(vector2 in){
     return length(vector(in.x, in.y, 0));
 }
 
-vector2 difference(vector2 fg, vector2 bg){
-    vector2 out = { difference(fg.x, bg.x),  
-                 difference(fg.y, bg.y)
-               };
+vector2 difference(vector2 fg, vector2 bg)
+{
+    vector2 out = { difference(fg.x, bg.x),
+                    difference(fg.y, bg.y)
+                  };
 
     return out;
 }
 
 vector2 rotate2d(vector2 in, float amount, vector2 center)
 {
-    vector2 out = in;
-    
+    vector2 out = in;    
     out.x = out.x - center.x;
     out.y = out.y - center.y;
     out.x = in.x*cos(amount) - in.y*sin(amount);

--- a/src/shaders/MaterialX/vector4.h
+++ b/src/shaders/MaterialX/vector4.h
@@ -35,7 +35,8 @@ vector4 make_vector4(float x)
     return out;
 }
 
-vector4 abs(vector4 in){
+vector4 abs(vector4 in)
+{
     vector4 out;
     out.x = abs(in.x);
     out.y = abs(in.y);
@@ -44,7 +45,8 @@ vector4 abs(vector4 in){
     return out;
 }
 
-vector4 floor(vector4 in){
+vector4 floor(vector4 in)
+{
     vector4 out;
     out.x = floor(in.x);
     out.y = floor(in.y);
@@ -53,7 +55,8 @@ vector4 floor(vector4 in){
     return out;
 }
 
-vector4 mix(vector4 value1, vector4 value2, float x ){
+vector4 mix(vector4 value1, vector4 value2, float x )
+{
     vector4 out;
     
     out.x = mix( value1.x, value2.x, x);
@@ -64,18 +67,21 @@ vector4 mix(vector4 value1, vector4 value2, float x ){
     return out;
 }
 
-vector vec4ToVec3(vector4 v){
+vector vec4ToVec3(vector4 v)
+{
     float s = 1/v.w;
     return vector(v.x * s,
                   v.y * s, 
                   v.z * s);
 }
 
-float dot(vector4 a, vector4 b){
-    return dot(vec4ToVec3(a), vec4ToVec3(b));
+float dot(vector4 a, vector4 b)
+{
+    return (a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w);
 }
 
-vector4 add(vector4 in, vector4 amount){
+vector4 add(vector4 in, vector4 amount)
+{
     vector4 out = in;
     out.x = in.x + amount.x;
     out.y = in.y + amount.y;
@@ -84,7 +90,8 @@ vector4 add(vector4 in, vector4 amount){
     return out;
 }
 
-vector4 add(vector4 in, float amount){
+vector4 add(vector4 in, float amount)
+{
     vector4 out = in;
     out.x = in.x + amount;
     out.y = in.y + amount;
@@ -93,7 +100,8 @@ vector4 add(vector4 in, float amount){
     return out;
 }
 
-vector4 subtract(vector4 in, vector4 amount){
+vector4 subtract(vector4 in, vector4 amount)
+{
     vector4 out = in;
     out.x = in.x - amount.x;
     out.y = in.y - amount.y;
@@ -102,7 +110,8 @@ vector4 subtract(vector4 in, vector4 amount){
     return out;
 }
 
-vector4 subtract(vector4 in, float amount){
+vector4 subtract(vector4 in, float amount)
+{
     vector4 out = in;
     out.x = in.x - amount;
     out.y = in.y - amount;
@@ -111,7 +120,8 @@ vector4 subtract(vector4 in, float amount){
     return out;
 }
 
-vector4 smoothstep(vector4 low, vector4 high, vector4 in){
+vector4 smoothstep(vector4 low, vector4 high, vector4 in)
+{
     vector4 out = in;
     out.x = smoothstep(low.x, high.x, in.x);
     out.y = smoothstep(low.y, high.y, in.y);
@@ -120,7 +130,8 @@ vector4 smoothstep(vector4 low, vector4 high, vector4 in){
     return out;
 }
 
-vector4 smoothstep(float low, float high, vector4 in){
+vector4 smoothstep(float low, float high, vector4 in)
+{
     vector4 out = in;
     out.x = smoothstep(low, high, in.x);
     out.y = smoothstep(low, high, in.y);
@@ -131,30 +142,31 @@ vector4 smoothstep(float low, float high, vector4 in){
 
 vector4 remap(vector4 in, vector4 inLow, vector4 inHigh, vector4 outLow, vector4 outHigh, int doClamp)
 {
-      //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
+    //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
 
-      vector4 out = in;
-      out.x = remap(in.x, inLow.x, inHigh.x, outLow.x, outHigh.x, doClamp);
-      out.y = remap(in.y, inLow.y, inHigh.y, outLow.y, outHigh.y, doClamp);
-      out.z = remap(in.z, inLow.z, inHigh.z, outLow.z, outHigh.z, doClamp);
-      out.w = remap(in.w, inLow.w, inHigh.w, outLow.w, outHigh.w, doClamp);
-      return out;
+    vector4 out = in;
+    out.x = remap(in.x, inLow.x, inHigh.x, outLow.x, outHigh.x, doClamp);
+    out.y = remap(in.y, inLow.y, inHigh.y, outLow.y, outHigh.y, doClamp);
+    out.z = remap(in.z, inLow.z, inHigh.z, outLow.z, outHigh.z, doClamp);
+    out.w = remap(in.w, inLow.w, inHigh.w, outLow.w, outHigh.w, doClamp);
+    return out;
 }
 
 vector4 remap(vector4 in, float inLow, float inHigh, float outLow, float outHigh, int doClamp)
 {
-      //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
+    //remap in from [inLow, inHigh] to [outLow, outHigh], optionally clamping to the new range
 
-      vector4 out = in;
-      out.x = remap(in.x, inLow, inHigh, outLow, outHigh, doClamp);
-      out.y = remap(in.y, inLow, inHigh, outLow, outHigh, doClamp);
-      out.z = remap(in.z, inLow, inHigh, outLow, outHigh, doClamp);
-      out.w = remap(in.w, inLow, inHigh, outLow, outHigh, doClamp);
+    vector4 out = in;
+    out.x = remap(in.x, inLow, inHigh, outLow, outHigh, doClamp);
+    out.y = remap(in.y, inLow, inHigh, outLow, outHigh, doClamp);
+    out.z = remap(in.z, inLow, inHigh, outLow, outHigh, doClamp);
+    out.w = remap(in.w, inLow, inHigh, outLow, outHigh, doClamp);
 
-      return out;
+    return out;
 }
 
-vector4 fgamma(vector4 in, vector4 g){
+vector4 fgamma(vector4 in, vector4 g)
+{
     vector4 out = in;
 
     out.x = fgamma(in.x, g.x);
@@ -164,7 +176,8 @@ vector4 fgamma(vector4 in, vector4 g){
       return out;
 }
 
-vector4 fgamma(vector4 in, float g){
+vector4 fgamma(vector4 in, float g)
+{
     vector4 out = in;
 
     out.x = fgamma(in.x, g);
@@ -174,7 +187,8 @@ vector4 fgamma(vector4 in, float g){
       return out;
 }
 
-vector4 invert(vector4 in, vector4 amount){
+vector4 invert(vector4 in, vector4 amount)
+{
     vector4 out = in;
     out.x = amount.x - in.x;
     out.y = amount.y - in.y;
@@ -184,7 +198,8 @@ vector4 invert(vector4 in, vector4 amount){
     return out;
 }
 
-vector4 invert(vector4 in, float amount){
+vector4 invert(vector4 in, float amount)
+{
     vector4 out = in;
     out.x = amount - in.x;
     out.y = amount - in.y;
@@ -194,12 +209,14 @@ vector4 invert(vector4 in, float amount){
     return out;
 }
 
-vector4 invert(vector4 in){
+vector4 invert(vector4 in)
+{
     vector4 out = invert(in, 1.0);
     return out;
 }
 
-vector4 clamp(vector4 in, vector4 low, vector4 high){
+vector4 clamp(vector4 in, vector4 low, vector4 high)
+{
     vector4 out = in;
     out.x = clamp(in.x, low.x, high.x);
     out.y = clamp(in.y, low.y, high.y);
@@ -208,7 +225,8 @@ vector4 clamp(vector4 in, vector4 low, vector4 high){
     return out;
 }
 
-vector4 clamp(vector4 in, float low, float high){
+vector4 clamp(vector4 in, float low, float high)
+{
     vector4 out = in;
     out.x = clamp(in.x, low, high);
     out.y = clamp(in.y, low, high);
@@ -217,7 +235,8 @@ vector4 clamp(vector4 in, float low, float high){
     return out;
 }
 
-vector4 contrast(vector4 in, vector4 amount, vector4 pivot){
+vector4 contrast(vector4 in, vector4 amount, vector4 pivot)
+{
     vector4 out = in;
     out.x = contrast(in.x, amount.x, pivot.x);
     out.y = contrast(in.y, amount.y, pivot.y);
@@ -226,7 +245,8 @@ vector4 contrast(vector4 in, vector4 amount, vector4 pivot){
     return out;
 }
 
-vector4 contrast(vector4 in, float amount, float pivot){
+vector4 contrast(vector4 in, float amount, float pivot)
+{
     vector4 out = in;
     out.x = contrast(in.x, amount, pivot);
     out.y = contrast(in.y, amount, pivot);
@@ -235,7 +255,8 @@ vector4 contrast(vector4 in, float amount, float pivot){
     return out;
 }
 
-vector4 divide(vector4 in1, vector4 amount){
+vector4 divide(vector4 in1, vector4 amount)
+{
     vector4 out = in1;
     out.x = in1.x / amount.x;
     out.y = in1.y / amount.y;
@@ -244,7 +265,8 @@ vector4 divide(vector4 in1, vector4 amount){
     return out;
 }
 
-vector4 divide(vector4 in1, float amount){
+vector4 divide(vector4 in1, float amount)
+{
     vector4 out = in1;
     out.x = in1.x / amount;
     out.y = in1.y / amount;
@@ -253,7 +275,8 @@ vector4 divide(vector4 in1, float amount){
     return out;
 }
 
-vector4 exponent(vector4 in, vector4 amount){
+vector4 exponent(vector4 in, vector4 amount)
+{
     vector4 out = in;
     out.x = exponent(in.x, amount.x);
     out.y = exponent(in.y, amount.y);
@@ -262,7 +285,8 @@ vector4 exponent(vector4 in, vector4 amount){
     return out;
 }
 
-vector4 exponent(vector4 in, float amount){
+vector4 exponent(vector4 in, float amount)
+{
     vector4 out = in;
     out.x = exponent(in.x, amount);
     out.y = exponent(in.y, amount);
@@ -272,7 +296,8 @@ vector4 exponent(vector4 in, float amount){
 }
 
 
-vector4 max(vector4 in, vector4 amount){
+vector4 max(vector4 in, vector4 amount)
+{
     vector4 out = in;
     out.x = max(in.x, amount.x);
     out.y = max(in.y, amount.y);
@@ -281,7 +306,8 @@ vector4 max(vector4 in, vector4 amount){
     return out;
 }
 
-vector4 max(vector4 in, float amount){
+vector4 max(vector4 in, float amount)
+{
     vector4 out = in;
     out.x = max(in.x, amount);
     out.y = max(in.y, amount);
@@ -290,7 +316,8 @@ vector4 max(vector4 in, float amount){
     return out;
 }
 
-vector4 normalize(vector4 in){
+vector4 normalize(vector4 in)
+{
     vector v = normalize(vec4ToVec3(in));
     vector4 out;
     out.x = v[0];
@@ -300,7 +327,8 @@ vector4 normalize(vector4 in){
     return out;
 }
 
-vector4 multiply(vector4 in1, vector4 amount){
+vector4 multiply(vector4 in1, vector4 amount)
+{
     vector4 out = in1;
     out.x = in1.x * amount.x;
     out.y = in1.y * amount.y;
@@ -309,7 +337,8 @@ vector4 multiply(vector4 in1, vector4 amount){
     return out;
 }
 
-vector4 multiply(vector4 in1, float amount){
+vector4 multiply(vector4 in1, float amount)
+{
     vector4 out = in1;
     out.x = in1.x * amount;
     out.y = in1.y * amount;
@@ -318,7 +347,8 @@ vector4 multiply(vector4 in1, float amount){
     return out;
 }
 
-vector4 min(vector4 in, vector4 amount){
+vector4 min(vector4 in, vector4 amount)
+{
     vector4 out = in;
     out.x = min(in.x, amount.x);
     out.y = min(in.y, amount.y);
@@ -328,7 +358,8 @@ vector4 min(vector4 in, vector4 amount){
     return out;
 }
 
-vector4 min(vector4 in, float amount){
+vector4 min(vector4 in, float amount)
+{
     vector4 out = in;
     out.x = min(in.x, amount);
     out.y = min(in.y, amount);
@@ -338,7 +369,8 @@ vector4 min(vector4 in, float amount){
     return out;
 }
 
-vector4 fmod(vector4 in, vector4 amount){
+vector4 fmod(vector4 in, vector4 amount)
+{
     vector4 out = in;
     out.x = fmod(in.x, amount.x);
     out.y = fmod(in.y, amount.y);
@@ -347,7 +379,8 @@ vector4 fmod(vector4 in, vector4 amount){
     return out;
 }
 
-vector4 fmod(vector4 in, float amount){
+vector4 fmod(vector4 in, float amount)
+{
     vector4 out = in;
     out.x = fmod(in.x, amount);
     out.y = fmod(in.y, amount);
@@ -356,14 +389,15 @@ vector4 fmod(vector4 in, float amount){
     return out;
 }
 
-float mag(vector4 in){
+float mag(vector4 in)
+{
     return length(vector(in.x/in.w, in.y/in.w, in.z/in.w));
 }
 
 vector4 difference(vector4 fg, vector4 bg){
-    vector4 out = { difference(fg.x, bg.x),  
-                 difference(fg.y, bg.y)                 ,
-                 difference(fg.z, bg.z),  
+    vector4 out = { difference(fg.x, bg.x),
+                 difference(fg.y, bg.y),
+                 difference(fg.z, bg.z),
                  difference(fg.w, bg.w)
                };
 


### PR DESCRIPTION
minor tidying of header files, moved function open bracket to own line.  Removes some whitespace.

mx_scale: add center back to result in vscale
mx_luminance dot prods against luma coeffs
mx_hueshift amount defaults to 0.5
mx_dot for vector2 and vector4 implemented per spec


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

