### PR TITLE
fix remap clamping and fbm iterator variable

### DIFF
--- a/src/shaders/MaterialX/mx_funcs.h
+++ b/src/shaders/MaterialX/mx_funcs.h
@@ -25,7 +25,7 @@ float remap(float in, float inLow, float inHigh, float outLow, float outHigh, in
 {
       float x = (in - inLow)/(inHigh-inLow);
       if (doClamp == 1) {
-           x = clamp(x, outLow, outHigh);
+           x = clamp(x, 0, 1);
       }
       return outLow + (outHigh - outLow) * x;
 }
@@ -34,7 +34,7 @@ color remap(color in, color inLow, color inHigh, color outLow, color outHigh, in
 {
       color x = (in - inLow) / (inHigh - inLow);
       if (doClamp == 1) {
-           x = clamp(x, outLow, outHigh);
+           x = clamp(x, 0, 1);
       }
       return outLow + (outHigh - outLow) * x;
 }
@@ -43,7 +43,7 @@ color remap(color in, float inLow, float inHigh, float outLow, float outHigh, in
 {
       color x = (in - inLow) / (inHigh - inLow);
       if (doClamp == 1) {
-           x = clamp(x, outLow, outHigh);
+           x = clamp(x, 0, 1);
       }
       return outLow + (outHigh - outLow) * x;
 }
@@ -251,10 +251,9 @@ float fBm( point position, int octaves, float lacunarity, float diminish, string
 {
     float out = 0;
     float amp = 1.0;
-    float i;
     point p = position;
 
-    for (i = 0;  i < octaves;  i += 1) {
+    for (int i = 0;  i < octaves;  i += 1) {
         out += amp * noise(noisetype, p);
         amp *= diminish;
         p *= lacunarity;
@@ -267,10 +266,9 @@ color fBm( point position, int octaves, float lacunarity, float diminish, string
 
     color out = 0;
     float amp = 1.0;
-    float i;
     point p = position;
 
-    for (i = 0;  i < octaves;  i += 1) {
+    for (int i = 0;  i < octaves;  i += 1) {
         out += amp * (color)noise(noisetype, p);
         amp *= diminish;
         p *= lacunarity;


### PR DESCRIPTION
The remap clamping was in correct.
In the fbm code i should be int not a float.

## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

